### PR TITLE
Fixed minor annoyance in tutorial docs

### DIFF
--- a/src/docs/guide/3. Tutorial.gdoc
+++ b/src/docs/guide/3. Tutorial.gdoc
@@ -181,13 +181,11 @@ class BootStrap {
 
       3.times {
          long id = it + 1
-         def user = new User(username: "user$id", enabled: true,
-            password: springSecurityService.encodePassword("password$id")).save()
+         def user = new User(username: "user$id", enabled: true, password: "password$id").save()
          UserRole.create user, roleUser
       }
 
-      def admin = new User(username: 'admin', enabled: true,
-         password: springSecurityService.encodePassword('admin123')).save()
+      def admin = new User(username: 'admin', enabled: true, password: 'admin123').save()
 
       UserRole.create admin, roleUser
       UserRole.create admin, roleAdmin, true


### PR DESCRIPTION
Ran into a minor annoyance while trying out the acltest tutorial. It turns out that when users are created in the tutorial, passwords are being doubly encoded - in Bootstrap and in User domain class's beforeInsert()/beforeUpdate() methods. Hence, I removed encoding of user/admin passwords in Bootstrap since encoding already occurs in User.beforeInsert().
