### PR TITLE
Updated the Spring Security version to 3.2.3.RELEASE

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -14,7 +14,7 @@ grails.project.dependency.resolution = {
 	}
 
 	dependencies {
-		String springSecurityVersion = '3.2.0.RC1'
+		String springSecurityVersion = '3.2.3.RELEASE'
 
 		compile "org.springframework.security:spring-security-acl:$springSecurityVersion", {
 			excludes 'aopalliance', 'commons-logging', 'ehcache', 'fest-assert', 'hsqldb',


### PR DESCRIPTION
The current Spring Security version declared in the BuildConfig.groovy file (3.2.0.RC1) is no longer available in Maven Central and probably in other repositories. There has been stable releases for the 3.2 series and the latest is 3.2.3.RELEASE. This pull request modifies the BuildConfig.groovy file to use the newer version.
