### PR TITLE
Set unique Ehcache manager name

### DIFF
--- a/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
@@ -146,7 +146,9 @@ class SpringSecurityAclGrailsPlugin extends Plugin {
 		objectIdentityRetrievalStrategy(GormObjectIdentityRetrievalStrategy)
 
 		// acl cache
-		aclCacheManager(EhCacheManagerFactoryBean)
+		aclCacheManager(EhCacheManagerFactoryBean) {
+			cacheManagerName = 'spring-security-acl-cache-' + UUID.randomUUID()
+		}
 		ehcacheAclCache(EhCacheFactoryBean) {
 			cacheManager = ref('aclCacheManager')
 			cacheName = 'aclCache'


### PR DESCRIPTION
Fix "Another unnamed CacheManager exists" error
Same as https://github.com/grails-plugins/grails-spring-security-core/commit/8e2f9813e1efa4a3f17103fc2e2e02969178e653

Related: spring-security-core issue https://github.com/grails-plugins/grails-spring-security-core/issues/152