### PR TITLE
grails 3.2 compatibility

### DIFF
--- a/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/springsecurity/acl/SpringSecurityAclGrailsPlugin.groovy
@@ -14,7 +14,7 @@
  */
 package grails.plugin.springsecurity.acl
 
-import org.codehaus.groovy.grails.commons.GrailsClassUtils as GCU
+import grails.util.GrailsClassUtils as GCU
 import org.springframework.cache.ehcache.EhCacheFactoryBean
 import org.springframework.cache.ehcache.EhCacheManagerFactoryBean
 import org.springframework.expression.spel.standard.SpelExpressionParser


### PR DESCRIPTION
org.codehaus.groovy.grails.commons.GrailsClassUtils not available in grails-core 3.2.0
