### PR TITLE
 Mark base class (AbstractAclObjectIdentity) as @DirtyCheck

### DIFF
--- a/plugin/src/main/groovy/grails/plugin/springsecurity/acl/AbstractAclObjectIdentity.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/acl/AbstractAclObjectIdentity.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.acl
 
+import grails.gorm.dirty.checking.DirtyCheck
+
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
@@ -25,6 +27,7 @@ import groovy.transform.ToString
  */
 @EqualsAndHashCode(includes=['aclClass', 'parent', 'owner', 'entriesInheriting'])
 @ToString(includeNames=true)
+@DirtyCheck
 abstract class AbstractAclObjectIdentity implements Serializable {
 
 	AclClass aclClass


### PR DESCRIPTION
Required (since GORM 6.1) for Dirty checking to correctly work(Section 1.2.13 at http://gorm.grails.org/latest/hibernate/manual/index.html#upgradeNotes)