### PR TITLE
Add DirtyCheck annotation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.0.0.BUILD-SNAPSHOT
+projectVersion=4.0.0.BSA
 grailsVersion=4.0.0.RC1
 gormVersion=7.0.0.RC2
 gradleWrapperVersion=4.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=4.0.0.BSA
+projectVersion=4.0.0.BSA-SNAPSHOT
 grailsVersion=4.0.0.RC1
 gormVersion=7.0.0.RC2
 gradleWrapperVersion=4.9

--- a/plugin/grails-app/services/grails/plugin/springsecurity/acl/AclObjectIdentityGormService.groovy
+++ b/plugin/grails-app/services/grails/plugin/springsecurity/acl/AclObjectIdentityGormService.groovy
@@ -26,11 +26,12 @@ class AclObjectIdentityGormService {
     @CompileDynamic
     @ReadOnly
     List<AclObjectIdentity> findAllByParentObjectIdAndParentAclClassName(Long objectId, String aclClassName) {
-        //findQueryByParentObjectIdAndParentAclClassName(objectId, aclClassName).list()
-        List<AclObjectIdentity> aclObjectIdentityList = findAll()
-        aclObjectIdentityList.findAll { AclObjectIdentity oid ->
-            (oid?.parent?.aclClass?.className == aclClassName) &&  ( oid?.parent?.objectId == objectId)
-        }
+        return findQueryByParentObjectIdAndParentAclClassName(objectId, aclClassName).list()
+        //This is the non-optimized version using in-memory filtering - huge performance hit on large datasets
+//        List<AclObjectIdentity> aclObjectIdentityList = findAll()
+//        aclObjectIdentityList.findAll { AclObjectIdentity oid ->
+//            (oid?.parent?.aclClass?.className == aclClassName) &&  ( oid?.parent?.objectId == objectId)
+//        }
     }
 
     @ReadOnly

--- a/plugin/grails-app/services/grails/plugin/springsecurity/acl/AclUtilService.groovy
+++ b/plugin/grails-app/services/grails/plugin/springsecurity/acl/AclUtilService.groovy
@@ -102,11 +102,12 @@ class AclUtilService {
 	 * Update the owner of the domain class instance.
 	 *
 	 * @param domainObject  the domain class instance
-	 * @param newOwnerUsername  the new username
+	 * @param newRecipient  can be a username, role name, Sid, or Authentication
 	 */
-	void changeOwner(domainObject, String newUsername) {
+	void changeOwner(domainObject, recipient) {
 		MutableAcl acl = readAcl(domainObject)
-		acl.owner = new PrincipalSid(newUsername)
+		Sid newSid = createSid(recipient)
+		acl.owner = newSid
 		aclService.updateAcl acl
 	}
 

--- a/plugin/src/main/groovy/grails/plugin/springsecurity/acl/AbstractAclObjectIdentity.groovy
+++ b/plugin/src/main/groovy/grails/plugin/springsecurity/acl/AbstractAclObjectIdentity.groovy
@@ -14,6 +14,8 @@
  */
 package grails.plugin.springsecurity.acl
 
+import grails.gorm.dirty.checking.DirtyCheck
+
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 
@@ -25,6 +27,7 @@ import groovy.transform.ToString
  */
 @EqualsAndHashCode(includes=['aclClass', 'parent', 'owner', 'entriesInheriting'])
 @ToString(includeNames=true)
+@DirtyCheck
 abstract class AbstractAclObjectIdentity implements Serializable {
 
 	AclClass aclClass


### PR DESCRIPTION
Fixes issue when aclUtilService.changeOwner() doesn't persist changes to database due to AclObjectIdentity doesn't see changed property as dirty so it is never saved.

The DirtyCheck annotation has been added to the AbstractAclObjectIdentity class to improve change tracking. Additionally, a 'change owner' function with corresponding integration tests has been added to the AclUtilServiceSpec class to allow for changing the owner of an object. The tests ensure that the change in ownership is properly reflected in both Acl and persistent data.